### PR TITLE
Treat Clock explicitly, in addition to Scanner and Detector

### DIFF
--- a/OpenScanLib/OpenScanLib.vcxproj
+++ b/OpenScanLib/OpenScanLib.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="src\DeviceInterface.c" />
     <ClCompile Include="src\Modules.c" />
     <ClCompile Include="src\OpenScanAcquisition.c" />
+    <ClCompile Include="src\OpenScanClock.c" />
     <ClCompile Include="src\OpenScanDetector.c" />
     <ClCompile Include="src\OpenScanDevice.c" />
     <ClCompile Include="src\OpenScanDeviceModules.c" />

--- a/OpenScanLib/OpenScanLib.vcxproj.filters
+++ b/OpenScanLib/OpenScanLib.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClCompile Include="src\DeviceInterface.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\OpenScanClock.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\OpenScanLib.h">

--- a/OpenScanLib/include/OpenScanLib.h
+++ b/OpenScanLib/include/OpenScanLib.h
@@ -64,6 +64,7 @@ enum
 	OSc_Error_Driver_Not_Available,
 	OSc_Error_Device_Already_Open,
 	OSc_Error_Device_Not_Opened_For_LSM,
+	OSc_Error_Device_Does_Not_Support_Clock,
 	OSc_Error_Device_Does_Not_Support_Scanner,
 	OSc_Error_Device_Does_Not_Support_Detector,
 	OSc_Error_Wrong_Value_Type,
@@ -140,6 +141,7 @@ enum
 
 typedef struct OSc_LSM OSc_LSM;
 typedef struct OSc_Device OSc_Device;
+typedef struct OSc_Clock OSc_Clock;
 typedef struct OSc_Scanner OSc_Scanner;
 typedef struct OSc_Detector OSc_Detector;
 typedef struct OSc_Setting OSc_Setting;
@@ -158,6 +160,8 @@ void OSc_API OSc_DeviceModule_Set_Search_Paths(char **paths);
 
 OSc_Error OSc_API OSc_LSM_Create(OSc_LSM **lsm);
 OSc_Error OSc_API OSc_LSM_Destroy(OSc_LSM *lsm);
+OSc_Error OSc_API OSc_LSM_Get_Clock(OSc_LSM *lsm, OSc_Clock **clock);
+OSc_Error OSc_API OSc_LSM_Set_Clock(OSc_LSM *lsm, OSc_Clock *clock);
 OSc_Error OSc_API OSc_LSM_Get_Scanner(OSc_LSM *lsm, OSc_Scanner **scanner);
 OSc_Error OSc_API OSc_LSM_Set_Scanner(OSc_LSM *lsm, OSc_Scanner *scanner);
 OSc_Error OSc_API OSc_LSM_Get_Detector(OSc_LSM *lsm, OSc_Detector **detector);
@@ -171,8 +175,10 @@ OSc_Error OSc_API OSc_Device_Get_Name(OSc_Device *device, const char **name);
 OSc_Error OSc_API OSc_Device_Get_Display_Name(OSc_Device *device, const char **name);
 OSc_Error OSc_API OSc_Device_Open(OSc_Device *device, OSc_LSM *lsm);
 OSc_Error OSc_API OSc_Device_Close(OSc_Device *device);
+OSc_Error OSc_API OSc_Device_Has_Clock(OSc_Device *device, bool *hasClock);
 OSc_Error OSc_API OSc_Device_Has_Scanner(OSc_Device *device, bool *hasScanner);
 OSc_Error OSc_API OSc_Device_Has_Detector(OSc_Device *device, bool *hasDetector);
+OSc_Error OSc_API OSc_Device_Get_Clock(OSc_Device *device, OSc_Clock **clock);
 OSc_Error OSc_API OSc_Device_Get_Scanner(OSc_Device *device, OSc_Scanner **scanner);
 OSc_Error OSc_API OSc_Device_Get_Detector(OSc_Device *device, OSc_Detector **detector);
 OSc_Error OSc_API OSc_Device_Get_Settings(OSc_Device *device, OSc_Setting ***settings, size_t *count);
@@ -182,6 +188,8 @@ OSc_Error OSc_API OSc_Device_Get_Resolution(OSc_Device *device, size_t *width, s
 OSc_Error OSc_API OSc_Device_Set_Resolution(OSc_Device *device, size_t width, size_t height);
 OSc_Error OSc_API OSc_Device_Get_Magnification(OSc_Device *device, double *magnification);
 OSc_Error OSc_API OSc_Device_Set_Magnification(OSc_Device *device);
+
+OSc_Error OSc_API OSc_Clock_Get_Device(OSc_Clock *clock, OSc_Device **device);
 
 OSc_Error OSc_API OSc_Scanner_Get_Device(OSc_Scanner *scanner, OSc_Device **device);
 
@@ -221,7 +229,6 @@ OSc_Error OSc_API OSc_Setting_Get_Enum_Value_For_Name(OSc_Setting *setting, uint
 OSc_Error OSc_API OSc_Acquisition_Create(OSc_Acquisition **acq, OSc_LSM *lsm);
 OSc_Error OSc_API OSc_Acquisition_Destroy(OSc_Acquisition *acq);
 OSc_Error OSc_API OSc_Acquisition_Set_Number_Of_Frames(OSc_Acquisition *acq, uint32_t numberOfFrames);
-OSc_Error OSc_API OSc_Acquisition_Set_Trigger_Source(OSc_Acquisition *acq, OSc_Trigger_Source source);
 OSc_Error OSc_API OSc_Acquisition_Set_Frame_Callback(OSc_Acquisition *acq, OSc_Frame_Callback callback);
 OSc_Error OSc_API OSc_Acquisition_Get_Data(OSc_Acquisition *acq, void **data);
 OSc_Error OSc_API OSc_Acquisition_Set_Data(OSc_Acquisition *acq, void *data);

--- a/OpenScanLib/src/DeviceInterface.c
+++ b/OpenScanLib/src/DeviceInterface.c
@@ -41,16 +41,55 @@ static void *Setting_GetImplData(struct OScDev_ModuleImpl *modImpl, OScDev_Setti
 }
 
 
-static OScDev_Error Acquisition_GetNumberOfFrames(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *acq, uint32_t *numberOfFrames)
+static OScDev_Error Acquisition_GetNumberOfFrames(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, uint32_t *numberOfFrames)
 {
-	*numberOfFrames = acq->numberOfFrames;
+	*numberOfFrames = devAcq->acq->numberOfFrames;
 	return OScDev_OK;
 }
 
 
-static bool Acquisition_CallFrameCallback(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *acq, uint32_t channel, void *pixels)
+static OScDev_Error Acquisition_IsClockRequested(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, bool *isRequested)
 {
-	return acq->frameCallback(acq, channel, pixels, acq->data);
+	*isRequested = devAcq->device == devAcq->acq->clock->device;
+	return OScDev_OK;
+}
+
+
+static OScDev_Error Acquisition_IsScannerRequested(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, bool *isRequested)
+{
+	*isRequested = devAcq->device == devAcq->acq->scanner->device;
+	return OScDev_OK;
+}
+
+
+static OScDev_Error Acquisition_IsDetectorRequested(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, bool *isRequested)
+{
+	*isRequested = devAcq->device == devAcq->acq->detector->device;
+	return OScDev_OK;
+}
+
+
+static OScDev_Error Acquisition_GetClockStartTriggerSource(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, enum OScDev_TriggerSource *startTrigger)
+{
+	// At this moment we don't yet support external start trigger.
+	*startTrigger = OScDev_TriggerSource_Software;
+	return OScDev_OK;
+}
+
+
+static OScDev_Error Acquisition_GetClockSource(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, enum OScDev_ClockSource *clock)
+{
+	if (devAcq->device == devAcq->acq->clock->device)
+		*clock = OScDev_ClockSource_Internal;
+	else
+		*clock = OScDev_ClockSource_External;
+	return OScDev_OK;
+}
+
+
+static bool Acquisition_CallFrameCallback(struct OScDev_ModuleImpl *modImpl, OScDev_Acquisition *devAcq, uint32_t channel, void *pixels)
+{
+	return devAcq->acq->frameCallback(devAcq->acq, channel, pixels, devAcq->acq->data);
 }
 
 
@@ -61,5 +100,10 @@ struct OScDevInternal_Interface DeviceInterfaceFunctionTable = {
 	.Setting_Create = Setting_Create,
 	.Setting_GetImplData = Setting_GetImplData,
 	.Acquisition_GetNumberOfFrames = Acquisition_GetNumberOfFrames,
+	.Acquisition_IsClockRequested = Acquisition_IsClockRequested,
+	.Acquisition_IsScannerRequested = Acquisition_IsScannerRequested,
+	.Acquisition_IsDetectorRequested = Acquisition_IsDetectorRequested,
+	.Acquisition_GetClockStartTriggerSource = Acquisition_GetClockStartTriggerSource,
+	.Acquisition_GetClockSource = Acquisition_GetClockSource,
 	.Acquisition_CallFrameCallback = Acquisition_CallFrameCallback,
 };

--- a/OpenScanLib/src/OpenScanClock.c
+++ b/OpenScanLib/src/OpenScanClock.c
@@ -1,0 +1,8 @@
+#include "OpenScanLibPrivate.h"
+
+
+OSc_Error OSc_Clock_Get_Device(OSc_Clock *clock, OSc_Device **device)
+{
+	*device = clock->device;
+	return OSc_Error_OK;
+}

--- a/OpenScanLib/src/OpenScanLSM.c
+++ b/OpenScanLib/src/OpenScanLSM.c
@@ -36,6 +36,34 @@ OSc_Error OSc_LSM_Destroy(OSc_LSM *lsm)
 }
 
 
+OSc_Error OSc_LSM_Get_Clock(OSc_LSM *lsm, OSc_Clock **clock)
+{
+	if (!lsm || !clock)
+		return OSc_Error_Illegal_Argument;
+
+	*clock = lsm->clock;
+	return OSc_Error_OK;
+}
+
+
+OSc_Error OSc_LSM_Set_Clock(OSc_LSM *lsm, OSc_Clock *clock)
+{
+	if (!lsm || !clock)
+		return OSc_Error_Illegal_Argument;
+
+	OSc_Device *clockDevice;
+	OSc_Return_If_Error(OSc_Clock_Get_Device(clock, &clockDevice));
+
+	bool isAssociated = false;
+	OSc_Return_If_Error(OSc_LSM_Is_Device_Associated(lsm, clockDevice, &isAssociated));
+	if (!isAssociated)
+		return OSc_Error_Device_Not_Opened_For_LSM;
+
+	lsm->clock = clock;
+	return OSc_Error_OK;
+}
+
+
 OSc_Error OSc_LSM_Get_Scanner(OSc_LSM *lsm, OSc_Scanner **scanner)
 {
 	if (!lsm || !scanner)

--- a/OpenScanLib/src/OpenScanLibPrivate.h
+++ b/OpenScanLib/src/OpenScanLibPrivate.h
@@ -4,6 +4,11 @@
 #include "OpenScanDeviceLib.h"
 
 
+struct OSc_Clock
+{
+	OSc_Device *device;
+};
+
 struct OSc_Scanner
 {
 	OSc_Device *device;
@@ -24,6 +29,7 @@ struct OSc_Device
 
 	bool isOpen;
 
+	OSc_Clock *clock;
 	OSc_Scanner *scanner;
 	OSc_Detector *detector;
 
@@ -38,6 +44,7 @@ struct OSc_Device
 
 struct OSc_LSM
 {
+	OSc_Clock *clock;
 	OSc_Scanner *scanner;
 	OSc_Detector *detector;
 
@@ -55,14 +62,26 @@ struct OSc_Setting
 	char name[OSc_MAX_STR_LEN + 1];
 };
 
+struct OSc_AcquisitionForDevice
+{
+	OSc_Device *device;
+	OSc_Acquisition *acq;
+};
+
 struct OSc_Acquisition
 {
+	OSc_Clock *clock;
 	OSc_Scanner *scanner;
 	OSc_Detector *detector;
 	uint32_t numberOfFrames;
-	OSc_Trigger_Source triggerSource;
 	OSc_Frame_Callback frameCallback;
 	void *data;
+
+	// We can pass opaque pointers to these structs to devices, so that we can
+	// handle acquisition-related calls in a device-specific manner.
+	struct OSc_AcquisitionForDevice acqForClockDevice;
+	struct OSc_AcquisitionForDevice acqForScannerDevice;
+	struct OSc_AcquisitionForDevice acqForDetectorDevice;
 };
 
 

--- a/TestDeviceModule/TestDevice.c
+++ b/TestDeviceModule/TestDevice.c
@@ -65,6 +65,13 @@ static OScDev_Error TestClose(OScDev_Device *device)
 }
 
 
+static OScDev_Error TestHasClock(OScDev_Device *device, bool *hasClock)
+{
+	*hasClock = false;
+	return OScDev_OK;
+}
+
+
 static OScDev_Error TestHasScanner(OScDev_Device *device, bool *hasScanner)
 {
 	*hasScanner = false;
@@ -86,8 +93,10 @@ struct OScDev_DeviceImpl g_TestDeviceImpl = {
 	.GetName = TestGetName,
 	.Open = TestOpen,
 	.Close = TestClose,
+	.HasClock = TestHasClock,
 	.HasScanner = TestHasScanner,
 	.HasDetector = TestHasDetector,
+	// Other required methods omitted.
 };
 
 


### PR DESCRIPTION
Devices and applications will need to be updated.

Devices will need to:
- Add an implementation for `HasClock`.
- Replace the implementations of `ArmScanner`, `ArmDetector`, `StartScanner`, and `StartDetector` with `Arm` and `Start`. `Arm` arms the clock, scanner, and detector (as specified by the acquisition), and `Start` (only required if the device can provide the clock) starts the clock.
- Replace the implementations of `StopScanner` and `StopDetector` with the single `Stop` function.
See the Doxygen documentation for details.

Applications will need to:
- Specify the clock to use for an LSM (`OSc_LSM_Set_Clock`)
- Remove any use of `OSc_Acquisition_Set_Trigger_Source`