### PR TITLE
Device with no detectors enabled should not participate in acquisition

### DIFF
--- a/OpenScanLib/src/Acquisition.c
+++ b/OpenScanLib/src/Acquisition.c
@@ -89,7 +89,7 @@ OSc_RichError *OSc_Acquisition_Create(OSc_Acquisition **acq,
             uint32_t nch;
             err = OScInternal_Device_GetNumberOfChannels(detectorDevice, &nch);
             assert(err == OSc_OK); // Given earlier GetNumberOfChannels
-            if (nch >= 0) {
+            if (nch > 0) {
                 OScInternal_PtrArray_Append((*acq)->detectorDevices,
                                             detectorDevice);
                 OScInternal_NumArray_Append((*acq)->channelOffsets,


### PR DESCRIPTION
Matches the code to the existing comment.

Might be good to test on an NIDAQ + BH_SPC system to make sure this does not change behavior when all SPC channels are disabled.